### PR TITLE
Fix Statamic 6 multisite support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.8",
-        "orchestra/testbench": "^8.5",
-        "mockery/mockery": "^1.6"
+        "orchestra/testbench": "^8.5"
     },
     "scripts": {
         "lint": [

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.8",
-        "orchestra/testbench": "^8.5"
+        "orchestra/testbench": "^8.5",
+        "mockery/mockery": "^1.6"
     },
     "scripts": {
         "lint": [
@@ -47,5 +48,5 @@
             "pixelfear/composer-dist-plugin": true
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }

--- a/src/Tags/Googlefonts.php
+++ b/src/Tags/Googlefonts.php
@@ -46,12 +46,7 @@ class Googlefonts extends Tags
         // replace the APP_URL with the site's URL
         // this is for multi-site support
         if (Site::hasMultiple()) {
-            // add a trailing slash, just in case
-            $appUrl = config('app.url');
-            if (!str_ends_with($appUrl, '/')) {
-                $appUrl .= '/';
-            }
-            $loaded = str_replace('src: url('.$appUrl, 'src: url('.URL::getSiteUrl(), $loaded);
+            $loaded = str_replace('src: url('.config('app.url'), 'src: url('.Site::current()->absoluteUrl(), $loaded);
         }
 
         return $loaded;

--- a/tests/Tags/GooglefontsTest.php
+++ b/tests/Tags/GooglefontsTest.php
@@ -23,6 +23,7 @@ beforeEach(function () {
         config('google-fonts.fonts'),
         config('google-fonts.preload'),
     ])->makePartial();
+
 });
 
 test('it can load the default font', function () {
@@ -105,13 +106,12 @@ test('it correctly applies full URLs for multisite', function () {
         'multi' => [
             'name' => 'Multi Site',
             'locale' => 'en_AU',
-            'url' => 'https://my-multi-site.com',
+            'url' => 'https://www.my-multi-site.com',
         ]
     ]);
 
-    // set the multi-site URL
-    URL::shouldReceive('getSiteUrl')->andReturn('https://www.my-multi-site.com/');
-    expect(URL::getSiteUrl())->toBe('https://www.my-multi-site.com/');
+    // switch to the other site
+    Site::setCurrent('multi');
 
     // do another call, and should not be localhost, but use the newly set domain
     /*


### PR DESCRIPTION
Statamic 6 has removed `URL::getSiteUrl()`, so a different approach is needed.

Resolves #6 